### PR TITLE
Bugfix/problem UUID resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ docker run -d \
   renderer:1.0
 ```
 
-If you have non-OPL content, it should be mounted as a volume at `/usr/app/private`.
+If you have non-OPL content, it can be mounted as a volume at `/usr/app/private` by adding the following line to the `docker run` command:
 
 ```
-docker run -d \
-  --publish 3000:3000 \
-  --mount type=bind,source="$(pwd)"/volumes/webwork-open-problem-library/,target=/usr/app/webwork-open-problem-library \
   --mount type=bind,source=/pathToYourLocalContentRoot,target=/usr/app/private \
-  renderer:1.0
+```
+
+A default configuration file is included in the container, but it can be overridden by mounting a replacement at the application root.
+
+```
+  --mount type=bind,source=/pathToYour/configuration_file.conf,target=/usr/app/render_app.conf \
 ```
 
 ## LOCAL INSTALL ###

--- a/lib/RenderApp/Controller/Render.pm
+++ b/lib/RenderApp/Controller/Render.pm
@@ -85,7 +85,7 @@ async sub problem {
   $inputs_ref->{formURL} ||= $ENV{formURL};
 
   my $problem_contents;
-  if ( $inputs_ref->{problemSource} =~ /Mojo::Promise/ ) {
+  if ( $inputs_ref->{problemSource} && $inputs_ref->{problemSource} =~ /Mojo::Promise/ ) {
     $problem_contents = await $inputs_ref->{problemSource};
     if ( $problem_contents ) {
       $c->log->info("Problem source fetched from $inputs_ref->{problemSourceURL}");

--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -18,6 +18,7 @@ use String::ShellQuote;
 use Cwd 'abs_path';
 use JSON::XS;
 use Crypt::JWT qw( encode_jwt );
+use Digest::MD5 qw( md5_hex );
 
 use lib "$WeBWorK::Constants::WEBWORK_DIRECTORY/lib";
 use lib "$WeBWorK::Constants::PG_DIRECTORY/lib";

--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -90,7 +90,6 @@ sub process_pg_file {
       'MathJax';    #	is there any reason for this to be anything else?
     $inputHash->{sourceFilePath} ||= $file_path;
     $inputHash->{outputFormat}   ||= 'static';
-    $inputHash->{problemSeed}    ||= $problem_seed;
     $inputHash->{language}       ||= 'en';
 
     # HACK: required for problemRandomize.pl
@@ -197,6 +196,7 @@ sub process_problem {
         #$inputs_ref->{pathToProblemFile} = $adj_file_path;
     }
     my $raw_metadata_text = $1 if ($source =~ /(.*?)DOCUMENT\(\s*\)\s*;/s);
+    $inputs_ref->{problemUUID} = md5_hex($source);
 
     # TODO verify line ending are LF instead of CRLF
 

--- a/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.js
@@ -44,6 +44,7 @@ function createAnswerQuill() {
 				answerQuill.input.val('');
 				answerQuill.latexInput.val('');
 			}
+			answerQuill.input.get(0).dispatchEvent(new Event('input', { bubbles: true }));
 		},
 		// Disable the toolbar when a text block is entered.
 		textBlockEnter: function() {

--- a/render_app.conf.dist
+++ b/render_app.conf.dist
@@ -1,10 +1,11 @@
 {
-  secrets => ['reveal_your_secrets','revelio','alohamora'],
+  secrets => ['abracadabra'],
   baseURL => '',
   formURL => '/render-api',
-  problemJWTsecret => "shared",
-  webworkJWTsecret => "private",
-  SITE_HOST => "http://localhost:3000",
+  problemJWTsecret => 'shared',
+  webworkJWTsecret => 'private',
+  SITE_HOST => 'http://localhost:3000',
+  CORS_ORIGIN => '*',
   hypnotoad => {
     listen => ['http://*:3000'],
     accepts => 400,


### PR DESCRIPTION
This fixes issue #56 - naming of resource files.

Problem source will always be hashed, and that hash will be used as the problemUUID. This should ensure that changes in the problem source code will always result in resource files with different names.