### PR TITLE
Added Submodule checkout to Github Action

### DIFF
--- a/.github/workflows/createContainer.yml
+++ b/.github/workflows/createContainer.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it        
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       
       - name: Extract branch/tag name
         shell: bash


### PR DESCRIPTION
Docker images were missing the PG module since by default submodules aren't checked out. This causes are runtime error since the application cannot start without this submodule.