### PR TITLE
Update /render-api to ANY

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -77,7 +77,7 @@ sub startup {
 	# Routes to controller
 	my $r = $self->routes;
 
-	$r->post('/render-api')->to('render#problem');
+	$r->any('/render-api')->to('render#problem');
 	$r->any('/health' => sub {shift->rendered(200)});
 	if ($self->mode eq 'development') {
 		$r->any('/')->to('pages#twocolumn');


### PR DESCRIPTION
Modifies /render-api to ANY so that it is more similar to deprecated /rendered endpoint. 

@drdrew42 indicates that this may need to be paired with a change such as `STRICT_JWT`.