### PR TITLE
support strict-mode requiring JWT on render req

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ If you have non-OPL content, it can be mounted as a volume at `/usr/app/private`
   --mount type=bind,source=/pathToYourLocalContentRoot,target=/usr/app/private \
 ```
 
-A default configuration file is included in the container, but it can be overridden by mounting a replacement at the application root.
+A default configuration file is included in the container, but it can be overridden by mounting a replacement at the application root. This is necessary if, for example, you want to run the container in `production` mode.
 
 ```
-  --mount type=bind,source=/pathToYour/configuration_file.conf,target=/usr/app/render_app.conf \
+  --mount type=bind,source=/pathToYour/render_app.conf,target=/usr/app/render_app.conf \
 ```
 
 ## LOCAL INSTALL ###

--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -43,7 +43,7 @@ sub startup {
 	$self->plugin('Config');
 	$self->plugin('TagHelpers');
 	$self->secrets($self->config('secrets'));
-	for ( qw(problemJWTsecret webworkJWTsecret baseURL formURL SITE_HOST MOJO_MODE STRICT_JWT) ) {
+	for ( qw(problemJWTsecret webworkJWTsecret baseURL formURL SITE_HOST STRICT_JWT) ) {
 		$ENV{$_} //= $self->config($_);
 	};
 

--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -43,7 +43,7 @@ sub startup {
 	$self->plugin('Config');
 	$self->plugin('TagHelpers');
 	$self->secrets($self->config('secrets'));
-	for ( qw(problemJWTsecret webworkJWTsecret baseURL formURL SITE_HOST MOJO_MODE) ) {
+	for ( qw(problemJWTsecret webworkJWTsecret baseURL formURL SITE_HOST MOJO_MODE STRICT_JWT) ) {
 		$ENV{$_} //= $self->config($_);
 	};
 

--- a/lib/RenderApp/Controller/Render.pm
+++ b/lib/RenderApp/Controller/Render.pm
@@ -8,7 +8,7 @@ use WeBWorK::Form;
 sub parseRequest {
   my $c = shift;
   my %params = WeBWorK::Form->new_from_paramable($c->req)->Vars;
-  if ($c->app->mode eq 'production' && !( defined $params{problemJWT} || defined $params{sessionJWT} )) {
+  if ($ENV{STRICT_JWT} && !( defined $params{problemJWT} || defined $params{sessionJWT} )) {
     $c->exception('Not allowed to request problems with raw data.', 403);
     return undef;
   }

--- a/render_app.conf.dist
+++ b/render_app.conf.dist
@@ -7,6 +7,7 @@
   SITE_HOST => 'http://localhost:3000',
   CORS_ORIGIN => '*',
   MOJO_MODE => 'development',
+  STRICT_JWT => 0,
   hypnotoad => {
     listen => ['http://*:3000'],
     accepts => 400,

--- a/render_app.conf.dist
+++ b/render_app.conf.dist
@@ -6,7 +6,6 @@
   webworkJWTsecret => 'private',
   SITE_HOST => 'http://localhost:3000',
   CORS_ORIGIN => '*',
-  MOJO_MODE => 'development',
   STRICT_JWT => 0,
   hypnotoad => {
     listen => ['http://*:3000'],


### PR DESCRIPTION
`render_app.conf` now supports a new boolean configuration variable, `STRICT_JWT`.

When defined and non-zero, `STRICT_JWT` will reject any /render-api request that does not include either a problemJWT or sessionJWT.

The default value for `STRICT_JWT` is 0 (false).