### PR TITLE
Fix base href / baseURL

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -47,10 +47,16 @@ sub startup {
 		$ENV{$_} //= $self->config($_);
 	};
 
-	# convert to absolute URLs
 	$ENV{baseURL} = '' if ( $ENV{baseURL} eq '/' );
 	$ENV{SITE_HOST} =~ s|/$||;  # remove trailing slash
-	# $ENV{baseURL} = $ENV{SITE_HOST} . $ENV{baseURL} if ( $ENV{baseURL} !~ m|^https?://| );
+
+	# $r needs to be defined before the SITE_HOST is added to the baseURL
+	my $r = $self->routes->under($ENV{baseURL});
+
+	# while iFrame embedded problems are likely to need the baseURL to include SITE_HOST
+	# convert to absolute URLs
+	$ENV{baseURL} = $ENV{SITE_HOST} . $ENV{baseURL} if ( $ENV{baseURL} !~ m|^https?://| );
+
 	$ENV{formURL} = $ENV{SITE_HOST} . $ENV{baseURL} . $ENV{formURL} if ( $ENV{formURL} !~ m|^https?://| );
 
 	# Handle optional CORS settings
@@ -75,7 +81,6 @@ sub startup {
 	$self->helper(exception => sub { RenderApp::Controller::Render::exception(@_) });
 
 	# Routes to controller
-	my $r = $self->routes->under($ENV{baseURL});
 
 	$r->any('/render-api')->to('render#problem');
 	$r->any('/health' => sub {shift->rendered(200)});


### PR DESCRIPTION
After https://github.com/drdrew42/renderer/pull/75 was merged and before this patch, problems renderered into an iFrame by the edX XBlock under development would no longer be able to load the resource files (scripts, etc.) 

The PR revises the changes to `baseURL` made in https://github.com/drdrew42/renderer/commit/d74dded86d48da368246459864411d4960168fee (part of https://github.com/drdrew42/renderer/pull/75) in order to overcome that issue.

iFrame embedded problems are likely to need `baseURL` to be set as in the past, so the HTML output includes a non-empty setting for "base href", and so the `href` values for resource files includes the `SITE_HOST` portion. However, the changes in that commit needed the `SITE_HOST` portion not to be included when `$r` was being defined. As a result, the definition of `$r` was moved ahead to before the `baseURL` gets the `SITE_HOST` portion, which is again done as it was in the past.

The issue with the output was a result of the fact that the rendered HTML included in the JSON output included an empty "base href" and the resources were provided only with a relative URL. Ex:
```
<base href="">
<link rel="shortcut icon" href="/webwork2_files/images/favicon.ico">
<link rel="stylesheet" type="text/css" href="/webwork2_files/themes/math4/math4.css">
```
while before the changes in https://github.com/drdrew42/renderer/commit/d74dded86d48da368246459864411d4960168fee and after the patch these lines for Standalone on `localhost:3000` are:
```
<base href="http://localhost:3000">
<link rel="shortcut icon" href="http://localhost:3000/webwork2_files/images/favicon.ico">
<link rel="stylesheet" type="text/css" href="http://localhost:3000/webwork2_files/themes/math4/math4.css">
```

For example one sample problem looked as follows:
![WeBWorK-problem-in-edX-XBlock-iFrame-before-patch](https://user-images.githubusercontent.com/39089094/133099943-99883f12-c2c1-4bb8-a825-4db1cc208ef6.png)

After the patch, it again renders properly:
![WeBWorK-problem-in-edX-XBlock-iFrame-after-patch](https://user-images.githubusercontent.com/39089094/133100002-728a943c-c0ce-40a7-886c-dbe670b63f22.png)
