### PR TITLE
Honor the MathQuill disabled option set by a problem.

### DIFF
--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -523,22 +523,19 @@ sub generateJWTs {
 
 sub insert_mathquill_responses {
     my ( $form_data, $pg ) = @_;
-    for my $answerLabel ( keys %{ $pg->{pgcore}->{PG_ANSWERS_HASH} } ) {
-        my $mq_opts = $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}
-          ->{ans_eval}{rh_ans}{mathQuillOpts};
-        my $response_obj =
-          $pg->{pgcore}->{PG_ANSWERS_HASH}->{$answerLabel}->response_obj;
+    for my $answerLabel ( keys %{ $pg->{pgcore}{PG_ANSWERS_HASH} } ) {
+        my $mq_opts = $pg->{pgcore}{PG_ANSWERS_HASH}{$answerLabel}{ans_eval}{rh_ans}{mathQuillOpts} // '';
+        next if ( $mq_opts =~ /\s*disabled\s*/ );
+        my $response_obj = $pg->{pgcore}{PG_ANSWERS_HASH}{$answerLabel}->response_obj;
         for my $response ( $response_obj->response_labels ) {
             next if ( ref( $response_obj->{responses}{$response} ) );
             my $name = "MaThQuIlL_$response";
             push( @{ $response_obj->{response_order} }, $name );
             $response_obj->{responses}{$name} = '';
-            my $value =
-              defined( $form_data->{$name} ) ? $form_data->{$name} : '';
-            $pg->{body_text} .=
-              CGI::hidden( { -name => $name, -id => $name, -value => $value } );
-            $pg->{body_text} .= "<script>var ${name}_Opts = {$mq_opts}</script>"
-              if ($mq_opts);
+            my $value = defined( $form_data->{$name} ) ? $form_data->{$name} : '';
+            $pg->{body_text} .= CGI::hidden({
+                -name => $name, -id => $name, -value => $value, data_mq_opts => "$mq_opts"
+            });
         }
     }
 }

--- a/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.css
+++ b/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.css
@@ -32,7 +32,7 @@ span[id^=mq-answer]
     margin-left: 0
 }
 
-input[type=text].codeshard
+input[type=text].codeshard.mq-edit
 {
     display: none !important;
 }

--- a/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.js
+++ b/lib/WeBWorK/htdocs/js/apps/MathQuill/mqeditor.js
@@ -1,18 +1,21 @@
+"use strict"
+
 // initialize MathQuill
 var MQ = MathQuill.getInterface(2);
-answerQuills = {};
+var answerQuills = {};
 
 // Avoid conflicts with bootstrap.
 $.widget.bridge('uitooltip', $.ui.tooltip);
 
-function createAnswerQuill() {
+$("[id^=MaThQuIlL_]").each(function() {
 	var answerLabel = this.id.replace(/^MaThQuIlL_/, "");
 	var input = $("#" + answerLabel);
 	var inputType = input.attr('type');
-	if (typeof(inputType) != 'string' || inputType.toLowerCase() !== "text") return;
+	if (typeof(inputType) != 'string' || inputType.toLowerCase() !== "text" || !input.hasClass('codeshard')) return;
 
 	var answerQuill = $("<span id='mq-answer-" + answerLabel + "'></span>");
 	answerQuill.input = input;
+	input.addClass('mq-edit');
 	answerQuill.latexInput = $(this);
 
 	input.after(answerQuill);
@@ -30,8 +33,8 @@ function createAnswerQuill() {
 	};
 
 	// Merge options that are set by the problem.
-	if (this.id + '_Opts' in window)
-		$.extend(cfgOptions, cfgOptions, window[this.id + '_Opts']);
+	var optOverrides = answerQuill.latexInput.data("mq-opts");
+	if (typeof(optOverrides) == 'object') $.extend(cfgOptions, optOverrides);
 
 	// This is after the option merge to prevent handlers from being overridden.
 	cfgOptions.handlers = {
@@ -44,7 +47,6 @@ function createAnswerQuill() {
 				answerQuill.input.val('');
 				answerQuill.latexInput.val('');
 			}
-			answerQuill.input.get(0).dispatchEvent(new Event('input', { bubbles: true }));
 		},
 		// Disable the toolbar when a text block is entered.
 		textBlockEnter: function() {
@@ -174,6 +176,4 @@ function createAnswerQuill() {
 	}
 
 	answerQuills[answerLabel] = answerQuill;
-}
-
-$(function() { $("[id^=MaThQuIlL_]").each(createAnswerQuill); });
+});

--- a/lib/WeBWorK/lib/WebworkClient/classic_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/classic_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/json_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/json_format.pl
@@ -55,8 +55,8 @@ $nextBlock = <<'ENDPROBLEMTEMPLATE';
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 ENDPROBLEMTEMPLATE
 

--- a/lib/WeBWorK/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/jwe_secure_format.pl
@@ -35,8 +35,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/nosubmit_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/nosubmit_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/practice_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/practice_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/simple_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/simple_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/single_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/single_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/standard_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/standard_format.pl
@@ -35,8 +35,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files

--- a/lib/WeBWorK/lib/WebworkClient/static_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/static_format.pl
@@ -36,8 +36,8 @@ $extra_css_files
 <script type="text/javascript" src="$webwork_htdocs_url/themes/math4/math4.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js" integrity="sha512-qw2bX9KUhi7HLuUloyRsvxRlWJvj0u0JWVegc5tf7qsw47T0pwXZIk1Kyc0utTH3NlrpHtLa4HYTVUyHBr9Ufg==" crossorigin="anonymous"></script>
 
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js"></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mathquill.min.js" defer></script>
+<script type="text/javascript" src="$webwork_htdocs_url/js/apps/MathQuill/mqeditor.js" defer></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/submithelper.js"></script>
 
 $extra_js_files


### PR DESCRIPTION
For this to work the mqeditor javascript and css need to be updated to the current code from WeBWorK.

This is another thing that was missed in pg/webwork 2.16.

