### PR TITLE
Update the code that parses files added via ADD_JS_FILES and fix bootstrap js loading

### DIFF
--- a/lib/RenderApp/Controller/FormatRenderedProblem.pm
+++ b/lib/RenderApp/Controller/FormatRenderedProblem.pm
@@ -245,21 +245,17 @@ sub formatRenderedProblem {
 	my $extra_js_files = '';
 	if (ref($rh_result->{flags}{extra_js_files}) eq "ARRAY") {
 		my %jsFiles;
-		# Avoid duplicates
-		$jsFiles{$_->{file}} = $_->{external} for @{$rh_result->{flags}{extra_js_files}};
-		for (keys(%jsFiles)) {
-			if ($jsFiles{$_}) {
-				$extra_js_files .=
-					CGI::start_script({type => "text/javascript", src => $_})
-					. CGI::end_script()
-					. "\n";
-			} elsif (!$jsFiles{$_} && -f "$ENV{WEBWORK_ROOT}/htdocs/$_") {
-				$extra_js_files .=
-					CGI::start_script({type => "text/javascript", src => "$webwork_htdocs_url/$_"})
-					. CGI::end_script()
-					. "\n";
+		for (@{$rh_result->{flags}{extra_js_files}}) {
+			# Avoid duplicates
+			next if $jsFiles{$_->{file}};
+			$jsFiles{$_->{file}} = 1;
+			my $attributes = ref($_->{attributes}) eq "HASH" ? $_->{attributes} : {};
+			if ($_->{external}) {
+				$extra_js_files .= CGI::script({ src => $_->{file}, %$attributes}, '');
+			} elsif (!$_->{external} && -f "$ENV{WEBWORK_ROOT}/htdocs/$_->{file}") {
+				$extra_js_files .= CGI::script({src => "$webwork_htdocs_url/$_->{file}", %$attributes}, '');
 			} else {
-				$extra_js_files .= "<!-- $_ is not available in htdocs/ on this server -->\n";
+				$extra_js_files .= "<!-- $_->{file} is not available in htdocs/ on this server -->";
 			}
 		}
 	}

--- a/lib/WeBWorK/htdocs/themes/math4/math4.css
+++ b/lib/WeBWorK/htdocs/themes/math4/math4.css
@@ -673,7 +673,7 @@ input.correct { /* green */
     outline: thin dotted \9;
     /* IE6-9 */
 
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81, ,.6);
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
     -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
     box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(81,153,81,.6);
 
@@ -759,6 +759,12 @@ table.attemptResults td.FeedbackMessage { background-color:#EDE275;} /* Harvest 
 table.attemptResults td.ResultsWithoutError { background-color:#8F8;}
 span.ResultsWithErrorInResultsTable { color: inherit; background-color: inherit; } /* used to override the older red on white span */
 table.attemptResults td.ResultsWithError { background-color:#D69191; color: #000000} /* red */
+
+table.attemptResults span.answer-preview {
+	display: inline-block;
+	width: 100%;
+	height: 100%;
+}
 
 /*styles for the instructor comment box */
 

--- a/lib/WeBWorK/htdocs/themes/math4/math4.js
+++ b/lib/WeBWorK/htdocs/themes/math4/math4.js
@@ -1,3 +1,10 @@
+// Handle some bootstrap/jquery-ui conflicts.
+if ($.widget) {
+	$.widget.bridge('uibutton', $.ui.button);
+	$.widget.bridge('uitooltip', $.ui.tooltip);
+}
+if ($.fn.button.noConflict) $.fn.bootstrapBtn = $.fn.button.noConflict();
+
 // Object for toggling the sidebar
 var ToggleNavigation = function () {
     var threshold = 768
@@ -129,24 +136,8 @@ $(function(){
     $('#SMA_button').addClass('btn btn-primary');
     
 
-    // this finds the wztooltips object entries and adds
-    // bootstrap styling using popover to them
-    // check first that popover is defined 
-    // (work around for sage interacts which remove popover for some reason)
-	$("table.attemptResults td[onmouseover*='Tip']").each(function(index,elem) {
-		var data = $(this).attr('onmouseover').match(/Tip\('(.*)'/);	
-		if (data) { data = data[1] }; // not sure I understand this, but sometimes the match fails 
-		//on the presentation of a matrix  and then causes errors throughout the rest of the script
-		if ($.fn.popover) { 
-			$(this).attr('onmouseover','');
-			if (data) {
-				$(this).wrapInner('<div class="results-popover" />');
-				var popdiv = $('div', this);
-				popdiv.popover({placement:'bottom', html:'true', trigger:'click',content:data});	
-			}
-		} 
-	    
-	});
+    // Set up popovers in the attemptResults table.
+    if ($.fn.popover) { $("table.attemptResults td span.answer-preview").popover({ trigger: 'click' }); }
 
     // sets up problems to rescale the image accoring to attr height width
     // and not native height width.  

--- a/lib/WeBWorK/lib/WebworkClient/classic_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/classic_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/json_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/json_format.pl
@@ -47,7 +47,7 @@ $nextBlock = <<'ENDPROBLEMTEMPLATE';
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/jwe_secure_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/jwe_secure_format.pl
@@ -27,7 +27,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/nosubmit_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/nosubmit_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/practice_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/practice_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/simple_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/simple_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/single_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/single_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/standard_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/standard_format.pl
@@ -27,7 +27,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>

--- a/lib/WeBWorK/lib/WebworkClient/static_format.pl
+++ b/lib/WeBWorK/lib/WebworkClient/static_format.pl
@@ -28,7 +28,7 @@ $extra_css_files
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-chtml.min.js" defer integrity="sha512-OEN4O//oR+jeez1OLySjg7HPftdoSaKHiWukJdbFJOfi2b7W0r0ppziSgVRVNaG37qS1f9SmttcutYgoJ6rwNQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous"></script>
-<script type="text/javascript" src="$webwork_htdocs_url/js/legacy/java_init.js"></script>
+<script src="$webwork_htdocs_url/js/vendor/bootstrap/js/bootstrap.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/InputColor/color.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/apps/Base64/Base64.js"></script>
 <script type="text/javascript" src="$webwork_htdocs_url/js/legacy/vendor/knowl.js"></script>


### PR DESCRIPTION
Update the code that parses files added via ADD_JS_FILES to the current code in webwork2.  This preserves order of the requested files as well as honors the attributes that are passed.

I also noticed that the bootstrap javascript was not loaded in the formats.  This is needed for scaffolds and results table popovers to work.  The popovers need to be activated as well.  This is now done in the math4.js file.  The pertinent styles were also added in the math4.css file.

I removed the java_init.js file loaded in the templates.  That is certainly not needed.