### PR TITLE
Fix log directory path.

### DIFF
--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -41,7 +41,7 @@ our $UNIT_TESTS_ON = 0;
 # create log files :: expendable
 ##################################################
 
-my $path_to_log_file = 'logs/standalone_results.log';
+my $path_to_log_file = "$ENV{RENDER_ROOT}/logs/standalone_results.log";
 
 eval {    # attempt to create log file
     local (*FH);


### PR DESCRIPTION
The log directory should not be an absolute path.  If morbo or hypnotoad is run from another directory the logs directory is not found.