### PR TITLE
Make MathQuill optional

### DIFF
--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -421,7 +421,8 @@ sub standaloneRenderer {
           ['Problem failed during render - no PGcore received.'];
     }
 
-    insert_mathquill_responses( $inputs_ref, $pg );
+    insert_mathquill_responses( $inputs_ref, $pg )
+        if defined($inputs_ref->{entryAssist}) && $inputs_ref->{entryAssist} eq 'MathQuill';
 
     my $out2 = {
         text                    => $pg->{body_text},

--- a/public/navbar.js
+++ b/public/navbar.js
@@ -106,6 +106,7 @@ renderbutton.addEventListener("click", event => {
   formData.set("permissionLevel", 20);
   formData.set("includeTags", 1);
   formData.set("showComments", 1);
+  formData.set("entryAssist", "MathQuill");
   formData.set("sourceFilePath", document.getElementById('sourceFilePath').value);
   formData.set("problemSeed", document.getElementById('problemSeed').value);
   formData.set("outputFormat", outputFormat);
@@ -181,6 +182,7 @@ function insertListener() {
     formData.set("permissionLevel", 20);
     formData.set("includeTags", 1);
     formData.set("showComments", 1);
+	formData.set("entryAssist", 'MathQuill');
     formData.set("sourceFilePath", document.getElementById('sourceFilePath').value);
     formData.set("problemSeed", document.getElementById('problemSeed').value);
     formData.set("outputFormat", outputFormat);


### PR DESCRIPTION
The option is `entryAssist` as it was in webwork2, and is provided as a url parameter.  Set this equal to `MathQuill` to enable MathQuill.  Presumably we will also need to implement MathView as well, so `MathView` will be another value of this parameter that will be honored in the future.

It is assumed that the front end will provide the necessary javascript.

The standalone renderer sets this option, so it has MathQuill enabled by default.  The javascript is provided in the templates.