### PR TITLE
Add Cache-control and Expires headers for files under webwork2_files

### DIFF
--- a/lib/RenderApp.pm
+++ b/lib/RenderApp.pm
@@ -73,16 +73,14 @@ sub startup {
 	if (my $STATIC_EXPIRES = $self->config('STATIC_EXPIRES')) {
 	    $STATIC_EXPIRES = int( $STATIC_EXPIRES );
 	    my $cache_control_setting = "max-age=$STATIC_EXPIRES";
-	    my $no_cache_setting = "max-age=1, no-cache";
+	    my $no_cache_setting = 'max-age=1, no-cache';
 	    $self->hook(after_dispatch => sub {
 		my $c = shift;
 
 		# Only process if file requested is under webwork2_files
-		unless ( $c->req->url->path =~ '^/webwork2_files' ) {
-		    return;
-		}
+		return unless ($c->req->url->path =~ '^/webwork2_files/');
 
-		if ( $c->req->url->path =~ '/tmp/renderer' ) {
+		if ($c->req->url->path =~ '/tmp/renderer') {
 		    # Treat problem generated files as already expired.
 		    # They should not be cached.
 		    $c->res->headers->cache_control( $no_cache_setting );

--- a/render_app.conf.dist
+++ b/render_app.conf.dist
@@ -6,6 +6,7 @@
   webworkJWTsecret => 'private',
   SITE_HOST => 'http://localhost:3000',
   CORS_ORIGIN => '*',
+  STATIC_EXPIRES => 86400,
   STRICT_JWT => 0,
   hypnotoad => {
     listen => ['http://*:3000'],


### PR DESCRIPTION
Add a setting via `render_app.conf.dist` to set static files from `webwork2_files` to be cached by the browser, and to expire a set amount of time in the future. This should reduce server load regarding static files which are used by multiple problems, but still makes it reasonable to roll out updated files in a reasonable manner.

At present, we only add the response header settings to support browser caching for files under `webwork2_files`. However, we set expired times for those whose URL contains a match to `tmp/renderer` as files which were generated for a specific problem may be dangerous to cache, in case they get updated in any manner on a subsequent call.

The suggested default cache duration for static files was set to 24 hours (86400 seconds) in the sample `render.conf.dist file`.