### PR TITLE
maketext - patch so it works inside PG also

### DIFF
--- a/lib/RenderApp/Controller/RenderProblem.pm
+++ b/lib/RenderApp/Controller/RenderProblem.pm
@@ -93,6 +93,11 @@ sub process_pg_file {
     $inputHash->{outputFormat}   ||= 'static';
     $inputHash->{language}       ||= 'en';
 
+    # Set a course environment language setting (which is used for
+    # maketext in PG) based on the value set above. When an API call
+    # arrives and provides a setting, it will then be used.
+    $seed_ce->{language} = $inputHash->{language};
+
     # HACK: required for problemRandomize.pl
     $inputHash->{effectiveUser} = 'red.ted';
     $inputHash->{user}          = 'red.ted';


### PR DESCRIPTION
This continues work started in https://github.com/drdrew42/renderer/pull/66.

`maketext` calls inside PG were not using the language requested by the API request, as `lib/WeBWorK/lib/WeBWorK/PG.pm` sets
```
	$envir{language}            = $ce->{language};
```
(the language later used for `maketext` calls inside PG) and the `$seed_ce` created by the Standalone renderer was not providing a `language` setting.

To fix the issue we add a `language` setting to the `$seed_ce` which will get passed into PG.

The change is done so that the core PG code pulled in from outside the Standalone repository does not need to be modified.

After this PR the `maketext` inside PG should hopefully work as well as they do in webwork2 and pg version 2.16. (The limitations of `maketext` in `WWSafe` probably still apply, so `maketext` calls inside PG cannot use a parameter at present.) 

---

Testing can be done using via `localhost` when the renderer is running locally via Docker by checking the output of a page like `http://localhost:3000/render-api?sourceFilePath=Library/Mizzou/Algebra/inverse_functions_and_relations/find_dom_range_inv_graph_01.pg&problemSeed=1&outputFormat=simple&language=heb` before and after the patch. 

Before the patch, you should see `You can earn partial credit on this problem.` in English just above the buttons (which will be in Hebrew) and after the patch (and a restart of the container) you should see `ניתן לקבל ניקוד חלקי בשאלה זו.` in Hebrew.

Before the patch:
![BeforePatch](https://user-images.githubusercontent.com/39089094/151213315-09f2a9a0-c277-43d5-962a-7cf9a000aa66.png)

After the patch:
![AfterPatch](https://user-images.githubusercontent.com/39089094/151213323-d4446427-c7ef-4516-ab9a-b114f8eea903.png)

---

At present, Hebrew is the only language other than English for which there is a PO translation dictionary for the renderer.

Use of any invalid value for `language` will cause `maketext` to fall back to the default (English) phrases.
